### PR TITLE
Commands added for cli tool issue #9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 public
+template
 node_modules
 package-lock.json

--- a/src/flags/checkFlag.js
+++ b/src/flags/checkFlag.js
@@ -1,0 +1,85 @@
+const fs = require('fs');
+const pkg = require('../../package.json');
+const path = require("path");
+
+function getHelpMenu() {
+    console.log('====================================');
+    console.log('\tHelp Menu');
+    console.log('====================================\n');
+    console.log("Usage: npx donovan");
+    console.log("Use Commands: donovan --[full flag name] or donovan -[short flag name]");
+    console.log(`
+    Commands: 
+        \n--help or -h: Shows usable commands
+        \n--about or -v: Shows version and author information
+        \n--init or i: Initializes the config file
+        \n--clean or -c: Removes the public and template from directory`);
+};
+
+function getVersionInfo() {
+    console.log(pkg.version);
+};
+
+function generateConfig() {
+    console.log("Generating Config File...");
+
+    //code to generate config file
+};
+
+async function removePublicAndTemplate() {
+    console.log("Removing Public and Template...");
+    await remove("public");
+    await remove("template");
+};
+
+function remove(distName) {
+
+    if (fs.existsSync(process.cwd().toString() + '/' + distName)) {
+        fs.rm(path.join(process.cwd(), distName), { force: true, recursive: true }, (err) => {
+            if (err) {
+                console.log("######### Error: " + err + " #########");
+            }
+        });
+        console.log(distName + " Directory Removed");
+    } else {
+        console.log(distName + " Directory not found");
+    }
+};
+
+
+function checkFlag(flag) {
+    switch (flag) {
+        case "--help":
+            getHelpMenu();
+            break;
+        case "-h":
+            getHelpMenu();
+            break;
+        case "-v":
+            getVersionInfo();
+            break;
+        case "--about":
+            getVersionInfo();
+            break;
+        case "--init":
+            generateConfig();
+            break;
+        case "i":
+            generateConfig();
+            break;
+        case "--clean":
+            removePublicAndTemplate();
+            break;
+        case "-c":
+            removePublicAndTemplate();
+            break;
+
+        default:
+            console.log("########## Error: Invalid command " + flag + " ##########");
+            break;
+    }
+};
+
+module.exports = {
+    checkFlag,
+}

--- a/src/index.js
+++ b/src/index.js
@@ -3,25 +3,31 @@
 const { findRepoConfig, createBabelConfig, createNPMConfig, installDependencies } = require('./config/index.js');
 const { downloadFromGitUrl, cleanupAfterTemplate } = require('./template/download.js');
 const runTemplate = require('./generator/index.js');
+const { checkFlag } = require('./flags/checkFlag.js');
 
 const fs = require('fs');
 const path = require('path');
 
 global.templateDir = path.join(process.cwd(), "template");
 
-(async () => {
+(async() => {
 
     try {
 
-        const config = await findRepoConfig();
-        global = { ...global, project: config };
-        
-        console.log("Downloading Template from Git Url...");
-        await downloadFromGitUrl(global.project.template);
-        console.log("Generating Pages from Template...");
-        await runTemplate();
-        console.log("Cleaning Up Leftover Assets...");
-        await cleanupAfterTemplate();
+        if (process.argv.length > 2) {
+            console.log("Checking Flags " + process.argv[2] + "...");
+            checkFlag(process.argv[2]);
+        } else {
+            const config = await findRepoConfig();
+            global = {...global, project: config };
+
+            console.log("Downloading Template from Git Url...");
+            await downloadFromGitUrl(global.project.template);
+            console.log("Generating Pages from Template...");
+            await runTemplate();
+            console.log("Cleaning Up Leftover Assets...");
+            await cleanupAfterTemplate();
+        }
 
     } catch (e) {
 


### PR DESCRIPTION
The 'help', 'clean', and 'about' cli commands are added. I've put a bit more functionality and added short hands for the same. For eg:- 

help command is executed as:
     donovan --help or donovan -h 
about command is executed as:
     donovan --about or donovan -v
clean command is executed as:
     donovan --clean or donovan -c

We can change/remove any shorthand if that might be the case required. 

P.S. The npx donovan command should still work.